### PR TITLE
Add parents to git log message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 the [PEP 440 version scheme](https://peps.python.org/pep-0440/#version-scheme).
 
+## [1.4.0] - 2025-08-07
+### Added
+- Parent commit IDs to the log message produced by `log_git_status()`.
+
 ## [1.3.0] - 2025-08-05
 ### Added
 - `log_git_status()` function to service\_kit.logging.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dynamic = ["readme"]
 license = "GPLv3"
 name = "service-kit"
 requires-python = "^3.11"
-version = "v1.3.0"
+version = "v1.4.0"
 
 [tool.setuptools.dynamic]
 readme = {file = ["README.md"]}


### PR DESCRIPTION
There are scenarios where automated systems may build artifacts from merge commits. For example, when a GitHub Action is triggered by a PR, GitHub creates a merge commit that merges the PR branch into the target branch. The hash of this merge commit is useless, as it is short-lived and does not refer to any commit in the repository; instead, this commit is local to GitHub. By also logging the parent commit IDs, one can determine exactly what code is running.

References:
- https://github.com/orgs/community/discussions/26325
- https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request