### PR TITLE
Unsort log properties

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,3 +49,7 @@ repos:
     rev: v2.13
     hooks:
       - id: vulture
+  - repo: https://github.com/mssalvatore/changelog-formatter-commit-hook
+    rev: v1.0.1
+    hooks:
+      - id: changelog-formatter

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,6 +50,6 @@ repos:
     hooks:
       - id: vulture
   - repo: https://github.com/mssalvatore/changelog-formatter-commit-hook
-    rev: v1.0.1
+    rev: v1.0.2
     hooks:
       - id: changelog-formatter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ the [PEP 440 version scheme](https://peps.python.org/pep-0440/#version-scheme).
 ## [Unreleased]
 ### Added
 ### Changed
+- Leave structured log fields unsorted by default. This allows for a more natural ordering of fields. Fields can still be sorted by passing the  `sort_fields=True` parameter to `logging.configure_logger()`
 ### Deprecated
 ### Fixed
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,19 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 the [PEP 440 version scheme](https://peps.python.org/pep-0440/#version-scheme).
 
+
 ## [Unreleased]
 ### Added
 ### Changed
-- Leave structured log fields unsorted by default. This allows for a more natural ordering of fields. Fields can still be sorted by passing the  `sort_fields=True` parameter to `logging.configure_logger()`
+- Leave structured log fields unsorted by default. This allows for a more
+  natural ordering of fields. Fields can still be sorted by passing the
+  `sort_fields=True` parameter to `logging.configure_logger()`.
+
 ### Deprecated
 ### Fixed
 ### Removed
 ### Security
+
 
 ## [2.2.0] - 2026-07-01
 ### Added
@@ -21,9 +26,11 @@ the [PEP 440 version scheme](https://peps.python.org/pep-0440/#version-scheme).
 - `log_startup_information()` -- a shortcut for logging both the Python version
   and git status.
 
+
 ## [2.1.0] - 2026-04-05
 ### Added
 - `service_kit.configuration.FeatureFlag` pydantic type.
+
 
 ## [2.0.1] - 2026-02-05
 ### Changed
@@ -31,6 +38,7 @@ the [PEP 440 version scheme](https://peps.python.org/pep-0440/#version-scheme).
 
 ### Fixed
 - All dependency specifications to be PEP 508 compliant.
+
 
 ## [2.0.0] - 2025-11-19
 ### Added
@@ -49,17 +57,21 @@ the [PEP 440 version scheme](https://peps.python.org/pep-0440/#version-scheme).
 ### Changed
 - Allow use of ServiceKit with monkey-types 2.0.0.
 
+
 ## [1.4.0] - 2025-08-07
 ### Added
 - Parent commit IDs to the log message produced by `log_git_status()`.
+
 
 ## [1.3.0] - 2025-08-05
 ### Added
 - `log_git_status()` function to service\_kit.logging.
 
+
 ## [1.2.0.post1] - 2025-03-05
 ### Added
 - Documentation generated with Sphinx.
+
 
 ## [1.2.0] - 2025-02-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ the [PEP 440 version scheme](https://peps.python.org/pep-0440/#version-scheme).
 
 ## [Unreleased]
 ### Added
+- `sort_fields` parameter to logging.configure_logger()
+
 ### Changed
 - Leave structured log fields unsorted by default. This allows for a more
   natural ordering of fields. Fields can still be sorted by passing the

--- a/service_kit/logging/_logger.py
+++ b/service_kit/logging/_logger.py
@@ -44,6 +44,7 @@ class InterceptHandler(logging.Handler):
 class Serializer:
     def __init__(self, colorize: bool):
         self._indent: int | None = None
+        self._sort_fields = False
         self._colorize = colorize
         self._lexer = JsonLexer()
         self._formatter = TerminalTrueColorFormatter(style="rrt")
@@ -52,6 +53,9 @@ class Serializer:
         # A separate method to set this is needed as this option is not configured until after the
         # configuration file has been read, which is also after the logger has been imported.
         self._indent = 4 if pretty_print_logs else None
+
+    def set_sort_fields(self, sort_fields: bool):
+        self._sort_fields = sort_fields
 
     def __call__(self, record: loguru.Record):
         subset = {
@@ -73,7 +77,10 @@ class Serializer:
 
     def _serialize_json(self, subset: dict[str, Any]) -> str:
         return json.dumps(
-            subset, indent=self._indent, sort_keys=True, default=self._default_serializer
+            subset,
+            indent=self._indent,
+            sort_keys=self._sort_fields,
+            default=self._default_serializer,
         )
 
     @staticmethod
@@ -97,6 +104,7 @@ def configure_logger(
     log_directory: Path | None,
     pretty_print_logs: bool,
     log_file_prefix: str | None = None,
+    sort_fields: bool = False,
 ):
     """
     Configures the service's structured logger
@@ -108,8 +116,11 @@ def configure_logger(
     :param pretty_print_logs: Whether or not to pretty-print logs
     :param log_file_prefix: A string that will be prepended to any log files
                             that are created (default: None)
+    :param sort_fields: Whether or not to sort the fields alphabetically in the log messages
+                        (default: False)
     """
     serializer.set_pretty_print(pretty_print_logs)
+    serializer.set_sort_fields(sort_fields)
 
     # Remove default logger before adding new handlers.
     logger.remove()

--- a/service_kit/logging/testing/__init__.py
+++ b/service_kit/logging/testing/__init__.py
@@ -1,1 +1,2 @@
 from .fixtures import configure_test_logger as configure_test_logger
+from .fixtures import run_configure_test_logger as run_configure_test_logger

--- a/service_kit/logging/testing/fixtures.py
+++ b/service_kit/logging/testing/fixtures.py
@@ -5,5 +5,9 @@ from service_kit.logging import configure_logger
 
 @pytest.fixture(autouse=True, scope="session")
 def configure_test_logger(request):
+    run_configure_test_logger(request)
+
+
+def run_configure_test_logger(request):
     level = 0 if request.config.getoption("--show-logs") else 50000
     configure_logger(log_level=level, log_directory=None, pretty_print_logs=True)

--- a/tests/logging/conftest.py
+++ b/tests/logging/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+
+from service_kit.logging.testing import run_configure_test_logger
+
+
+# ServiceKit actually tests the logger itself, so the test logger is scoped per-module to avoid the
+# the logger tests impacting the logger in unrelated tests.
+@pytest.fixture(autouse=True, scope="module")
+def configure_test_logger(request):
+    run_configure_test_logger(request)

--- a/tests/logging/test_logger.py
+++ b/tests/logging/test_logger.py
@@ -1,0 +1,38 @@
+import json
+
+from service_kit.logging import configure_logger
+from service_kit.logging._logger import logger
+
+
+def _capture_log_record(**extra_fields) -> dict:
+    captured = []
+    handler_id = logger.add(
+        lambda message: captured.append(str(message)),
+        format="{extra[serialized]}",
+        level=0,
+    )
+    try:
+        logger.info("test", **extra_fields)
+    finally:
+        logger.remove(handler_id)
+    return json.loads(captured[0])
+
+
+def test_sort_fields_sorts_keys_alphabetically():
+    configure_logger(log_level=50000, log_directory=None, pretty_print_logs=False, sort_fields=True)
+
+    data = _capture_log_record(zebra=1, apple=2)
+
+    assert list(data.keys()) == sorted(data.keys())
+
+
+def test_sort_fields_disabled_preserves_insertion_order():
+    configure_logger(
+        log_level=50000, log_directory=None, pretty_print_logs=False, sort_fields=False
+    )
+
+    data = _capture_log_record(zebra=1, apple=2)
+    keys = list(data.keys())
+
+    assert keys.index("zebra") < keys.index("apple")
+    assert list(keys) != sorted(keys)


### PR DESCRIPTION
By default, do not sort the properties of the structured logs.